### PR TITLE
[NO-CARD] Add CLAUDE.md for Claude Code context

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,36 @@
+# terraform-path-hash
+
+## Purpose
+
+Terraform module that generates a SHA256 content hash of a file or directory path, used to force re-deployments when file contents change.
+
+## Stack
+
+- Language: HCL (Terraform) + Python 3
+- Runtime: Python 3 (invoked via `data.external`)
+
+## Common Commands
+
+```bash
+terraform init    # Initialize module
+terraform plan    # Preview changes
+terraform apply   # Apply changes
+```
+
+## Architecture Constraints
+
+- The `data.external` block in `main.tf` invokes `hash.py` via stdin/stdout JSON — any changes to `hash.py` must preserve the `{"path": ...}` input / `{"result": ...}` output contract
+- Hash ignores dot-prefixed files and directories (e.g. `.git`) — intentional
+- Hash includes relative file paths in the digest, not just contents — rename alone triggers a change
+
+## Key Files
+
+- `main.tf` — module inputs, `data.external` wiring, and output
+- `hash.py` — SHA256 hashing logic invoked by Terraform
+
+## Known Quirks
+
+- Module uses `python3` explicitly — ensure `python3` is on PATH in the execution environment
+- Hash is deterministic on file names + contents only; symlinks and permissions are not included
+
+@auto-context.md

--- a/auto-context.md
+++ b/auto-context.md
@@ -1,0 +1,6 @@
+<!-- auto-generated: monitored-files-hash: e3b0c44298fc -->
+<!-- Do not edit the auto-generated sections below -->
+<!-- To add persistent custom content, wrap it in: pinned / /pinned HTML comments -->
+
+## Stack (Auto-Detected)
+- (no stack detected)


### PR DESCRIPTION
# Jira card (URL): <!-- Jira URL -->

# Summary

Adds a `CLAUDE.md` file to provide Claude Code with repo-specific context for this Terraform module, and an `auto-context.md` generated by the EH plugin.

# Changes proposed in this pull request:
- Add `CLAUDE.md` with purpose, stack, commands, architecture constraints, key files, and known quirks for the `terraform-path-hash` module
- Add `auto-context.md` (auto-generated stack detection file)

# AI usage
- [ ] No AI was used
- [ ] AI-assisted code completion
- [ ] AI agents used to reason about or plan code
- [ ] AI agents used to generate or modify code
- [x] Code was 100% written by AI

If "No AI was used" is ticked, comment why AI was not utilised: <!-- add reasoning here -->

🤖 Generated with [Claude Code](https://claude.com/claude-code) | Session: 5db02fc6-88ab-4eca-8401-bfa39d96012d